### PR TITLE
Add RViz visualization and velocity vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,19 @@ When the camera detects cones, it gives positions *relative* to the car. We must
 > 5. As you drive around, your group’s guesses cluster tightly on the car’s true path, and their cone map fills in accurately.
 
 That is **fastSLAM with an EKF map** in the simplest terms!
+
+## Visualization Setup
+
+Launch the localization node together with RViz:
+
+```bash
+$ roslaunch AAM_LOCALIZTION localization.launch
+```
+
+RViz will show:
+
+* **TF** tree of `map` and `odom` frames.
+* **Path** display on `/robot_path` in bright green.
+* **MarkerArray** displays for `/particles_pub` and `/cone_loc`.
+* **Marker** display for `/visualization_loc`.
+* **Vector** display for `/velocity_vectors` showing the current velocity arrows.

--- a/src/AAM_LOCALIZTION/CMakeLists.txt
+++ b/src/AAM_LOCALIZTION/CMakeLists.txt
@@ -10,6 +10,8 @@ project(AAM_LOCALIZTION)
 find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
+  visualization_msgs
+  tf_conversions
 )
 
 ## System dependencies are found with CMake's conventions
@@ -102,10 +104,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES AAM_LOCALIZTION
-#  CATKIN_DEPENDS rospy std_msgs
-#  DEPENDS system_lib
+  CATKIN_DEPENDS rospy std_msgs visualization_msgs tf_conversions
 )
 
 ###########

--- a/src/AAM_LOCALIZTION/launch/localization.launch
+++ b/src/AAM_LOCALIZTION/launch/localization.launch
@@ -1,8 +1,15 @@
 <?xml version="1.0"?>
 <launch>
 
-    <node name="localization" pkg="AAM_LOCALIZTION" type="fastslamwithekf.py" output="screen"/>
-    <node  name="rviz2" pkg="rviz" type="rviz" args="-d $(find AAM_LOCALIZTION)/rviz/slam.rviz"/> 
+    <param name="use_sim_time" value="false"/>
+
+    <node pkg="AAM_LOCALIZTION" type="fastslamwithekf.py" name="uKalman_Filter_node" output="screen"/>
+
+    <node pkg="tf2_ros" type="static_transform_publisher"
+          name="map_to_odom"
+          args="0 0 0 0 0 0 map odom 100"/>
+
+    <node  name="rviz2" pkg="rviz" type="rviz" args="-d $(find AAM_LOCALIZTION)/rviz/slam.rviz"/>
 
 
 </launch>

--- a/src/AAM_LOCALIZTION/package.xml
+++ b/src/AAM_LOCALIZTION/package.xml
@@ -51,10 +51,16 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>visualization_msgs</build_depend>
+  <build_depend>tf_conversions</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>visualization_msgs</build_export_depend>
+  <build_export_depend>tf_conversions</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend>tf_conversions</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/AAM_LOCALIZTION/rviz/slam.rviz
+++ b/src/AAM_LOCALIZTION/rviz/slam.rviz
@@ -51,6 +51,9 @@ Visualization Manager:
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
       Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Name: TF
     - Class: rviz/MarkerArray
       Enabled: true
       Marker Topic: /cone_loc
@@ -62,7 +65,7 @@ Visualization Manager:
     - Alpha: 1
       Buffer Length: 1
       Class: rviz/Path
-      Color: 25; 255; 0
+      Color: 0; 255; 0
       Enabled: true
       Head Diameter: 0.30000001192092896
       Head Length: 0.20000000298023224
@@ -95,6 +98,14 @@ Visualization Manager:
       Enabled: true
       Marker Topic: /particles_pub
       Name: MarkerArray
+      Namespaces:
+        "": true
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /velocity_vectors
+      Name: Vectors
       Namespaces:
         "": true
       Queue Size: 100


### PR DESCRIPTION
## Summary
- update launch file to start slam node, static TF and RViz
- show TF, path, particles, cones and velocity arrows in RViz config
- publish velocity vectors and periodic logging in `fastslamwithekf.py`
- fix path timestamp and add visualization instructions
- add package dependencies for visualization

## Testing
- `python3 -m py_compile src/AAM_LOCALIZTION/src/fastslamwithekf.py`